### PR TITLE
Check for KeyEventKind in handler

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,8 +1,11 @@
 use crate::app::{App, AppResult};
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 
 /// Handles the key events and updates the state of [`App`].
 pub fn handle_key_events(key_event: KeyEvent, app: &mut App) -> AppResult<()> {
+    if key_event.kind != KeyEventKind::Press {
+        return Ok(());
+    }
     match key_event.code {
         // Exit application on `q`
         KeyCode::Char('q') => {


### PR DESCRIPTION
On some systems, windows for example, you get a key event for both KeyPressed and KeyRelease resulting in double the key events. This commit fixes that by checking the KeyEventKind in handle_key_events

So now Raffle will run on Windows 💯 