### PR TITLE
Add participants file as cmdline input

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 edition = "2021"
 
 [dependencies]
+clap = { version = "4.5.2", features = ["derive"] }
 crossterm = "0.26.1"
 rand = "0.8.5"
 ratatui = "0.21.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
 use rand::Rng;
 use ratatui::widgets::ListState;
-use std::{error, vec};
+use std::{error, path::Path, vec};
 
 use crate::data::{self, Participant};
 
@@ -28,9 +28,16 @@ pub struct App {
 
 impl Default for App {
     fn default() -> Self {
+        Self::new(Path::new("participants.txt"))
+    }
+}
+
+impl App {
+    /// Constructs a new instance of [`App`].
+    pub fn new(path: &Path) -> Self {
         let tab_titles = vec!["Home".to_string(), "Participants".to_string()];
 
-        let participants = data::read_participants_from_file().expect("Failed to read file");
+        let participants = data::read_participants_from_file(path).expect("Failed to read file");
 
         Self {
             running: true,
@@ -41,13 +48,6 @@ impl Default for App {
             spin_counter: 0,
             spin_winner: None,
         }
-    }
-}
-
-impl App {
-    /// Constructs a new instance of [`App`].
-    pub fn new() -> Self {
-        Self::default()
     }
 
     /// Set running to false to quit the application

--- a/src/data.rs
+++ b/src/data.rs
@@ -3,6 +3,7 @@ use std::{
     fmt,
     fs::File,
     io::{BufRead, BufReader},
+    path::Path,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -21,8 +22,8 @@ impl fmt::Display for Participant {
     }
 }
 
-pub fn read_participants_from_file() -> Result<Vec<Participant>, Box<dyn Error>> {
-    let file = File::open("participants.txt").expect("Could not read file: participants.txt");
+pub fn read_participants_from_file(path: &Path) -> Result<Vec<Participant>, Box<dyn Error>> {
+    let file = File::open(path).expect("Could not read file: participants.txt");
 
     let lines = BufReader::new(file).lines();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use clap::Parser;
 use raffle::app::{App, AppResult};
 use raffle::event::{Event, EventHandler};
 use raffle::handler::handle_key_events;
@@ -6,12 +7,24 @@ use raffle::tui::Tui;
 use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
 use std::io;
+use std::path::{PathBuf};
 
 const TICK_RATE: u64 = 100;
 
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+struct Args {
+    #[arg(short, long)]
+    participants_file: Option<PathBuf>,
+}
+
 fn main() -> AppResult<()> {
     // Create an application.
-    let mut app = App::new();
+    let args = Args::parse();
+    let mut app = match args.participants_file {
+        Some(path) => App::new(&path),
+        None => App::default(),
+    };
 
     // Initialize the terminal user interface.
     let backend = CrosstermBackend::new(io::stderr());


### PR DESCRIPTION
This adds Clap as a dependency and uses that to parse cmdline arguments. The participants list is added as an argument and used when creating the App
App gets a new "new" that takes a path as input, and the default implementation uses the old particpants.txt.

My idea is to go towards a version that can be installed with "cargo install" if you are up for that :)