### PR TITLE
Fix winner not being highlighted

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -188,9 +188,9 @@ impl<T: std::clone::Clone> StatefulList<T> {
         self.state.select(None);
     }
 
-    pub fn get_selected(&mut self) -> Option<T> {
+    pub fn get_selected(&mut self) -> Option<&mut T> {
         match self.state.selected() {
-            Some(index) => Some(self.items[index].clone()),
+            Some(index) => Some(&mut self.items[index]),
             _ => None,
         }
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -127,7 +127,19 @@ pub fn render_list<B: Backend>(app: &mut App, frame: &mut Frame<'_, B>, area: Re
                 }),
         )
         .highlight_style({
-            let winner_higlighted = { app.all_participants.get_selected() == app.spin_winner };
+            let winner_higlighted = {
+                match app.all_participants.get_selected() {
+                    Some(selected) => {
+                        if let Some(spin_winner) = &app.spin_winner {
+                            spin_winner.clone_into(selected);
+                            true
+                        } else {
+                            false
+                        }
+                    }
+                    None => false,
+                }
+            };
 
             if winner_higlighted {
                 styles::winner_highlight()


### PR DESCRIPTION
When someone wins we were calling get_selected and then setting is_winner on the value we get. The problem is that get_selected cloned the value making the mutation invalid.
Now get_selected returns an Option<&mut T>, which requires a couple of changes.